### PR TITLE
Enable server to support multiple connections

### DIFF
--- a/src/main/java/com/hamishrickerby/http_server/App.java
+++ b/src/main/java/com/hamishrickerby/http_server/App.java
@@ -1,5 +1,7 @@
 package com.hamishrickerby.http_server;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Created by rickerbh on 15/08/2016.
  */
@@ -13,13 +15,12 @@ public class App {
             System.exit(1);
         }
         SocketServer server = null;
+
         try {
             server = new SocketServer(port, rootDirectory);
             System.out.println("Mounted " + rootDirectory + " as the directory to serve from.");
             System.out.println("Server started on port " + port);
-            while (true) {
-                Thread.sleep(5000);
-            }
+            server.group.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/src/main/java/com/hamishrickerby/http_server/HTTPCompletionHandler.java
+++ b/src/main/java/com/hamishrickerby/http_server/HTTPCompletionHandler.java
@@ -1,6 +1,7 @@
 package com.hamishrickerby.http_server;
 
 import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.CompletionHandler;
 import java.util.concurrent.TimeUnit;
@@ -10,13 +11,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class HTTPCompletionHandler implements CompletionHandler<AsynchronousSocketChannel, Void> {
     ResponseFactory responseFactory;
+    AsynchronousServerSocketChannel listeningChannel;
 
-    public HTTPCompletionHandler(String rootDirectory) {
+    public HTTPCompletionHandler(String rootDirectory, AsynchronousServerSocketChannel listeningChannel) {
         responseFactory = new ResponseFactory(rootDirectory);
+        this.listeningChannel = listeningChannel;
     }
 
     @Override
     public void completed(AsynchronousSocketChannel ch, Void attachment) {
+        listeningChannel.accept(null, this);
         String requestText = extractRequestText(ch);
 
         Request request = new Request(requestText);

--- a/src/main/java/com/hamishrickerby/http_server/SocketServer.java
+++ b/src/main/java/com/hamishrickerby/http_server/SocketServer.java
@@ -2,18 +2,21 @@ package com.hamishrickerby.http_server;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.channels.AsynchronousChannelGroup;
 import java.nio.channels.AsynchronousServerSocketChannel;
+import java.util.concurrent.Executors;
 
 /**
  * Created by rickerbh on 14/08/2016.
  */
 public class SocketServer {
     final AsynchronousServerSocketChannel listener;
+    final AsynchronousChannelGroup group = AsynchronousChannelGroup.withThreadPool(Executors.newSingleThreadExecutor());
 
     public SocketServer(int portNumber, String rootDirectory) throws IOException {
-        listener = AsynchronousServerSocketChannel.open();
+        listener = AsynchronousServerSocketChannel.open(group);
         listener.bind(new InetSocketAddress(portNumber));
-        listener.accept(null, new HTTPCompletionHandler(rootDirectory));
+        listener.accept(null, new HTTPCompletionHandler(rootDirectory, listener));
     }
 
     public void close() {

--- a/src/test/java/com/hamishrickerby/http_server/HTTPCompletionHandlerTest.java
+++ b/src/test/java/com/hamishrickerby/http_server/HTTPCompletionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.hamishrickerby.http_server;
 
+import com.hamishrickerby.http_server.mocks.MockAsynchronousServerSocketChannel;
 import com.hamishrickerby.http_server.mocks.MockAsynchronousSocketChannel;
 import junit.framework.TestCase;
 
@@ -17,7 +18,7 @@ public class HTTPCompletionHandlerTest extends TestCase {
     }
 
     private String runRequestAndGetResponse(String request) {
-        HTTPCompletionHandler handler = new HTTPCompletionHandler("./src/test/resources");
+        HTTPCompletionHandler handler = new HTTPCompletionHandler("./src/test/resources", new MockAsynchronousServerSocketChannel(null));
         MockAsynchronousSocketChannel channel = new MockAsynchronousSocketChannel(null);
         channel.setReadData(ByteBuffer.wrap(request.getBytes()));
 

--- a/src/test/java/com/hamishrickerby/http_server/mocks/MockAsynchronousServerSocketChannel.java
+++ b/src/test/java/com/hamishrickerby/http_server/mocks/MockAsynchronousServerSocketChannel.java
@@ -1,0 +1,65 @@
+package com.hamishrickerby.http_server.mocks;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.channels.spi.AsynchronousChannelProvider;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+/**
+ * Created by rickerbh on 17/08/2016.
+ */
+public class MockAsynchronousServerSocketChannel extends AsynchronousServerSocketChannel {
+    public MockAsynchronousServerSocketChannel(AsynchronousChannelProvider provider) {
+        super(provider);
+    }
+
+    @Override
+    public AsynchronousServerSocketChannel bind(SocketAddress local, int backlog) throws IOException {
+        return null;
+    }
+
+    @Override
+    public <T> AsynchronousServerSocketChannel setOption(SocketOption<T> name, T value) throws IOException {
+        return null;
+    }
+
+    @Override
+    public <A> void accept(A attachment, CompletionHandler<AsynchronousSocketChannel, ? super A> handler) {
+
+    }
+
+    @Override
+    public Future<AsynchronousSocketChannel> accept() {
+        return null;
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public <T> T getOption(SocketOption<T> name) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Set<SocketOption<?>> supportedOptions() {
+        return null;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+}


### PR DESCRIPTION
Provide a thread group to the connection handler.
Connection handler reenables processing after accepting an connection.
Get App main to wait for the server group to terminate before exiting - replacing the Thread.sleep(5000) infinite loop.

App already supports image data retrieval.
